### PR TITLE
Issue 6

### DIFF
--- a/Simple Icon File Maker/Simple Icon File Maker/Helpers/BitmapImageExtensions.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Helpers/BitmapImageExtensions.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media.Imaging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage.Streams;
+
+namespace Simple_Icon_File_Maker.Helpers;
+
+public static class BitmapImageExtensions
+{
+    public static async Task CheckAndSetSourceAsync(this BitmapImage bitmapImage, IRandomAccessStream fileStream)
+    {
+    try
+    {
+        await bitmapImage.SetSourceAsync(fileStream);
+    }
+    catch (Exception ex)
+    {
+        ContentDialog dialog = new ContentDialog()
+        {
+            Title = "Error",
+            Content = "An error occurred: " + ex.Message,
+            PrimaryButtonText = "Ok"
+        };
+            dialog.XamlRoot = MainWindow.Current.Content.XamlRoot;
+        await dialog.ShowAsync();
+        return;
+    }
+    }
+}

--- a/Simple Icon File Maker/Simple Icon File Maker/Helpers/BitmapImageExtensions.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Helpers/BitmapImageExtensions.cs
@@ -1,10 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
-using Microsoft.UI.Xaml.Media.Imaging;
+﻿using Microsoft.UI.Xaml.Media.Imaging;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage.Streams;
 
@@ -12,23 +7,15 @@ namespace Simple_Icon_File_Maker.Helpers;
 
 public static class BitmapImageExtensions
 {
-    public static async Task CheckAndSetSourceAsync(this BitmapImage bitmapImage, IRandomAccessStream fileStream)
+    public static async Task CheckAndSetSourceAsync(this BitmapImage bitmapImage, MainWindow mainWindow, IRandomAccessStream fileStream)
     {
-    try
-    {
-        await bitmapImage.SetSourceAsync(fileStream);
-    }
-    catch (Exception ex)
-    {
-        ContentDialog dialog = new ContentDialog()
+        try
         {
-            Title = "Error",
-            Content = "An error occurred: " + ex.Message,
-            PrimaryButtonText = "Ok"
-        };
-            dialog.XamlRoot = MainWindow.Current.Content.XamlRoot;
-        await dialog.ShowAsync();
-        return;
-    }
+            await bitmapImage.SetSourceAsync(fileStream);
+        }
+        catch (Exception ex)
+        {
+            mainWindow.ShowErrorInfoBar(ex.Message);
+        }
     }
 }

--- a/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml
+++ b/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml
@@ -8,33 +8,38 @@
     xmlns:models="using:Simple_Icon_File_Maker.Models"
     mc:Ignorable="d">
 
-    <Grid>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="360" />
-            <ColumnDefinition Width="*" />
-        </Grid.ColumnDefinitions>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="360" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
 
-        <Grid.RowDefinitions>
-            <RowDefinition Height="auto" />
-            <RowDefinition Height="*" />
-        </Grid.RowDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
 
-        <!--  Right side:  -->
+            <!--  Right side:  -->
 
-        <Grid
+            <Grid
             Grid.RowSpan="2"
             Grid.Column="1"
             AllowDrop="True"
             Background="{ThemeResource SystemControlBaseLowAcrylicWindowBrush}"
             DragOver="Border_DragOver"
             Drop="Grid_Drop">
+
+                <!-- Error Info Bar -->
+                
+            <InfoBar x:Name="errorInfoBar" Title="An Error Has Occured" Severity="Error"/>
+
             <Canvas
                 Name="dropHere"
                 Width="210"
                 Height="120"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
-                <Rectangle
+                    <Rectangle
                     Width="210"
                     Height="120"
                     RadiusX="20"
@@ -42,156 +47,156 @@
                     Stroke="{ThemeResource SystemAccentColor}"
                     StrokeDashArray="5"
                     StrokeLineJoin="Round" />
-                <StackPanel
+                    <StackPanel
                     Margin="20"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Vertical">
-                    <SymbolIcon Height="40" Symbol="Copy" />
-                    <TextBlock Text="Drag and Drop image here" />
-                </StackPanel>
-            </Canvas>
-            <Viewbox>
-                <Image
+                        <SymbolIcon Height="40" Symbol="Copy" />
+                        <TextBlock Text="Drag and Drop image here" />
+                    </StackPanel>
+                </Canvas>
+                <Viewbox>
+                    <Image
                     x:Name="MainImage"
                     Margin="36"
                     Stretch="Uniform" />
-            </Viewbox>
-        </Grid>
+                </Viewbox>
+            </Grid>
 
-        <!--  Left side:  -->
+            <!--  Left side:  -->
 
-        <StackPanel
+            <StackPanel
             Grid.Column="0"
             Padding="20"
             Background="{ThemeResource SystemControlAccentAcrylicElementAccentMediumHighBrush}"
             Orientation="Vertical"
             Spacing="26">
-            <Button
+                <Button
                 x:Name="OpenBTN"
                 Width="200"
                 HorizontalAlignment="Center"
                 Click="OpenBTN_Click">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <SymbolIcon Symbol="OpenFile" />
-                    <TextBlock
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <SymbolIcon Symbol="OpenFile" />
+                        <TextBlock
                         Width="120"
                         Text="Open Image"
                         TextAlignment="Center" />
-                </StackPanel>
-            </Button>
-            <Button
+                    </StackPanel>
+                </Button>
+                <Button
                 x:Name="SaveBTN"
                 Width="200"
                 HorizontalAlignment="Center"
                 Click="SaveBTN_Click"
                 IsEnabled="False">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <SymbolIcon Symbol="Save" />
-                    <TextBlock
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <SymbolIcon Symbol="Save" />
+                        <TextBlock
                         Width="120"
                         Text="Save Icon"
                         TextAlignment="Center" />
-                </StackPanel>
-            </Button>
-            <Button
+                    </StackPanel>
+                </Button>
+                <Button
                 x:Name="SaveAllBTN"
                 Width="200"
                 HorizontalAlignment="Center"
                 Click="SaveAllBTN_Click"
                 IsEnabled="False">
-                <StackPanel Orientation="Horizontal" Spacing="12">
-                    <SymbolIcon Symbol="SaveLocal" />
-                    <TextBlock
+                    <StackPanel Orientation="Horizontal" Spacing="12">
+                        <SymbolIcon Symbol="SaveLocal" />
+                        <TextBlock
                         Width="120"
                         Text="Save All Images"
                         TextAlignment="Center" />
-                </StackPanel>
-            </Button>
-            <Expander
+                    </StackPanel>
+                </Button>
+                <Expander
                 Width="200"
                 HorizontalAlignment="Center"
                 VerticalAlignment="Top"
                 ExpandDirection="Down"
                 Header="Icon Sizes"
                 IsExpanded="False">
-                <StackPanel Orientation="Vertical">
-                    <StackPanel Orientation="Horizontal" Spacing="12">
-                        <Button
+                    <StackPanel Orientation="Vertical">
+                        <StackPanel Orientation="Horizontal" Spacing="12">
+                            <Button
                             x:Name="RefreshButton"
                             HorizontalAlignment="Center"
                             Click="RefreshButton_Click">
-                            <StackPanel Orientation="Horizontal" Spacing="12">
-                                <SymbolIcon Symbol="Refresh" />
-                            </StackPanel>
-                        </Button>
-                        <Button
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <SymbolIcon Symbol="Refresh" />
+                                </StackPanel>
+                            </Button>
+                            <Button
                             x:Name="SelectAllButton"
                             HorizontalAlignment="Center"
                             Click="SelectAllButton_Click">
-                            <StackPanel Orientation="Horizontal" Spacing="12">
-                                <SymbolIcon Symbol="SelectAll" />
-                            </StackPanel>
-                        </Button>
-                        <Button
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <SymbolIcon Symbol="SelectAll" />
+                                </StackPanel>
+                            </Button>
+                            <Button
                             x:Name="ClearSelectionButton"
                             HorizontalAlignment="Center"
                             Click="ClearSelectionButton_Click">
-                            <StackPanel Orientation="Horizontal" Spacing="12">
-                                <SymbolIcon Symbol="ClearSelection" />
-                            </StackPanel>
-                        </Button>
-                    </StackPanel>
-                    <ListView
+                                <StackPanel Orientation="Horizontal" Spacing="12">
+                                    <SymbolIcon Symbol="ClearSelection" />
+                                </StackPanel>
+                            </Button>
+                        </StackPanel>
+                        <ListView
                         x:Name="IconSizesListView"
                         ItemsSource="{x:Bind IconSizes}"
                         SelectionMode="None">
-                        <ListView.ItemTemplate>
-                            <DataTemplate x:DataType="models:IconSize">
-                                <CheckBox IsChecked="{x:Bind IsSelected, Mode=TwoWay}">
-                                    <TextBlock Text="{x:Bind Tooltip}" />
-                                </CheckBox>
-                            </DataTemplate>
-                        </ListView.ItemTemplate>
-                    </ListView>
-                </StackPanel>
-            </Expander>
-        </StackPanel>
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="models:IconSize">
+                                    <CheckBox IsChecked="{x:Bind IsSelected, Mode=TwoWay}">
+                                        <TextBlock Text="{x:Bind Tooltip}" />
+                                    </CheckBox>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+                    </StackPanel>
+                </Expander>
+            </StackPanel>
 
-        <ScrollViewer
+            <ScrollViewer
             Grid.Row="1"
             Background="{ThemeResource SystemControlAccentAcrylicElementAccentMediumHighBrush}"
             VerticalScrollBarVisibility="Auto">
-            <Grid>
-                <ProgressRing
+                <Grid>
+                    <ProgressRing
                     x:Name="ImagesProcessingProgressRing"
                     Width="50"
                     Height="50"
                     IsActive="False"
                     IsIndeterminate="True"
                     Visibility="Collapsed" />
-                <StackPanel
+                    <StackPanel
                     Name="PreviewStackPanel"
                     Margin="24,12,24,100"
                     Orientation="Vertical"
                     Spacing="20" />
 
-            </Grid>
-        </ScrollViewer>
+                </Grid>
+            </ScrollViewer>
 
-        <CommandBar Grid.Row="1" VerticalAlignment="Bottom">
-            <CommandBar.PrimaryCommands>
-                <AppBarButton
+            <CommandBar Grid.Row="1" VerticalAlignment="Bottom">
+                <CommandBar.PrimaryCommands>
+                    <AppBarButton
                     x:Name="InfoAppBarButton"
                     Click="InfoAppBarButton_Click"
                     Icon="Help"
                     Label="About" />
-                <AppBarButton
+                    <AppBarButton
                     x:Name="ClearAppBarButton"
                     Click="ClearAppBarButton_Click"
                     Icon="Clear"
                     Label="Clear" />
-            </CommandBar.PrimaryCommands>
-        </CommandBar>
-    </Grid>
+                </CommandBar.PrimaryCommands>
+            </CommandBar>
+        </Grid>
 </Window>

--- a/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml
+++ b/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml
@@ -30,8 +30,19 @@
             Drop="Grid_Drop">
 
                 <!-- Error Info Bar -->
-                
-            <InfoBar x:Name="errorInfoBar" Title="An Error Has Occured" Severity="Error"/>
+
+            <InfoBar x:Name="errorInfoBar" Title="An Error Has Occured" Severity="Error">
+                <InfoBar.Resources>
+                    <Storyboard x:Name="closeInfoBarStoryboard">
+                        <ObjectAnimationUsingKeyFrames
+                            Storyboard.TargetName="errorInfoBar"
+                            Storyboard.TargetProperty="IsOpen"
+                            Duration="0:0:5">
+                            <DiscreteObjectKeyFrame KeyTime="0:0:5" Value="False"/>
+                        </ObjectAnimationUsingKeyFrames>
+                    </Storyboard>
+                </InfoBar.Resources>
+            </InfoBar>
 
             <Canvas
                 Name="dropHere"

--- a/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
@@ -35,8 +35,6 @@ public sealed partial class MainWindow : Window
     private Size? SourceImageSize;
     private readonly AppWindow? m_AppWindow;
 
-    private DispatcherTimer _timer;
-
     ObservableCollection<IconSize> IconSizes = new(IconSize.GetFullWindowsSizes());
 
     public MainWindow()
@@ -46,10 +44,6 @@ public sealed partial class MainWindow : Window
         m_AppWindow = GetAppWindowForCurrentWindow();
         m_AppWindow.SetIcon("SimpleIconMaker.ico");
         m_AppWindow.Title = "Simple Icon File Maker";
-
-        _timer = new DispatcherTimer();
-        _timer.Interval = TimeSpan.FromSeconds(5);
-        _timer.Tick += Timer_Tick;
 
         IconSizes.CollectionChanged += IconSizes_CollectionChanged;
     }
@@ -445,12 +439,7 @@ public sealed partial class MainWindow : Window
     {
         errorInfoBar.Message = errorMessage;
         errorInfoBar.IsOpen = true;
-        _timer.Start();
-    }
-    private void Timer_Tick(object? sender, object e)
-    {
-        errorInfoBar.IsOpen = false;
-        _timer.Stop();
+        closeInfoBarStoryboard.Begin();
     }
 
 }

--- a/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
@@ -5,6 +5,7 @@ using Microsoft.UI.Windowing;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.UI.Xaml.Media.Imaging;
+using Simple_Icon_File_Maker.Helpers;
 using Simple_Icon_File_Maker.Models;
 using System;
 using System.Collections.Generic;
@@ -49,7 +50,7 @@ public sealed partial class MainWindow : Window
 
     private void IconSizes_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
-        
+
     }
 
     private AppWindow GetAppWindowForCurrentWindow()
@@ -90,7 +91,8 @@ public sealed partial class MainWindow : Window
         // It's generally a good optimisation to decode to match the size you'll display
         // bitmapImage.DecodePixelHeight = decodePixelHeight;
         // bitmapImage.DecodePixelWidth = decodePixelWidth;
-        await bitmapImage.SetSourceAsync(fileStream);
+        await bitmapImage.CheckAndSetSourceAsync(this, fileStream);
+        if (errorInfoBar.IsOpen) return;
         SourceImageSize = new(bitmapImage.PixelWidth, bitmapImage.PixelHeight);
         MainImage.Source = bitmapImage;
         await SourceImageUpdated(Path.GetFileName(ImagePath));
@@ -227,7 +229,8 @@ public sealed partial class MainWindow : Window
                 DecodePixelWidth = sideLength
             };
 
-            await bitmapImage.SetSourceAsync(fileStream);
+            await bitmapImage.CheckAndSetSourceAsync(this, fileStream);
+            if (errorInfoBar.IsOpen) return;
 
             Image image = new()
             {
@@ -375,7 +378,8 @@ public sealed partial class MainWindow : Window
                     // bitmapImage.DecodePixelHeight = decodePixelHeight;
                     // bitmapImage.DecodePixelWidth = decodePixelWidth;
 
-                    await bitmapImage.SetSourceAsync(fileStream);
+                    await bitmapImage.CheckAndSetSourceAsync(this, fileStream);
+                    if (errorInfoBar.IsOpen) return;
                     SourceImageSize = new(bitmapImage.PixelWidth, bitmapImage.PixelHeight);
                     MainImage.Source = bitmapImage;
                     ImagePath = file.Path;
@@ -430,4 +434,10 @@ public sealed partial class MainWindow : Window
 
         IconSizesListView.UpdateLayout();
     }
+    public void ShowErrorInfoBar(string errorMessage)
+    {
+        errorInfoBar.Message = errorMessage;
+        errorInfoBar.IsOpen = true;
+    }
+
 }

--- a/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/MainWindow.xaml.cs
@@ -35,6 +35,8 @@ public sealed partial class MainWindow : Window
     private Size? SourceImageSize;
     private readonly AppWindow? m_AppWindow;
 
+    private DispatcherTimer _timer;
+
     ObservableCollection<IconSize> IconSizes = new(IconSize.GetFullWindowsSizes());
 
     public MainWindow()
@@ -45,8 +47,13 @@ public sealed partial class MainWindow : Window
         m_AppWindow.SetIcon("SimpleIconMaker.ico");
         m_AppWindow.Title = "Simple Icon File Maker";
 
+        _timer = new DispatcherTimer();
+        _timer.Interval = TimeSpan.FromSeconds(5);
+        _timer.Tick += Timer_Tick;
+
         IconSizes.CollectionChanged += IconSizes_CollectionChanged;
     }
+
 
     private void IconSizes_CollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
     {
@@ -438,6 +445,12 @@ public sealed partial class MainWindow : Window
     {
         errorInfoBar.Message = errorMessage;
         errorInfoBar.IsOpen = true;
+        _timer.Start();
+    }
+    private void Timer_Tick(object? sender, object e)
+    {
+        errorInfoBar.IsOpen = false;
+        _timer.Stop();
     }
 
 }


### PR DESCRIPTION
This aims to address issue 6 by encompassing the SetSourceAsync method in a try/catch block contained in a BitmapImage extension method. This will cause an InfoBar element to open and close after 5 seconds.

The Grid_Drop event has branching else if blocks that could still cause this error to happen.
```C#
        if (e.DataView.Contains(StandardDataFormats.Bitmap))
        {
            e.Handled = true;
            DragOperationDeferral def = e.GetDeferral();
            RandomAccessStreamReference s = await e.DataView.GetBitmapAsync();
            ImagePath = await e.DataView.GetTextAsync();

            BitmapImage bitmapImage = new();
            await bitmapImage.SetSourceAsync(await s.OpenReadAsync());
            SourceImageSize = new(bitmapImage.PixelWidth, bitmapImage.PixelHeight);
            MainImage.Source = bitmapImage;
            e.AcceptedOperation = DataPackageOperation.Copy;
            await SourceImageUpdated(Path.GetFileName(ImagePath));
            def.Complete();
        }

```

Let me know what you think.