### PR TITLE
Fix About Page Expander Move Right (#46) & Remove useless window creation

### DIFF
--- a/Simple Icon File Maker/Simple Icon File Maker/App.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/App.xaml.cs
@@ -7,7 +7,6 @@ using Simple_Icon_File_Maker.Services;
 using Simple_Icon_File_Maker.Activation;
 using Simple_Icon_File_Maker.Models;
 using Simple_Icon_File_Maker.Views;
-using WinUIEx;
 using Simple_Icon_File_Maker.ViewModels;
 
 namespace Simple_Icon_File_Maker;
@@ -35,7 +34,7 @@ public partial class App : Application
         return service;
     }
 
-    public static WindowEx MainWindow { get; } = new MainWindow();
+    public static MainWindow MainWindow { get; } = new MainWindow();
 
     public static UIElement? AppTitlebar { get; set; }
 
@@ -97,6 +96,5 @@ public partial class App : Application
         await App.GetService<IActivationService>().ActivateAsync(args);
     }
 
-    public static Window? m_window { get; } = new MainWindow();
     public static string[]? cliArgs { get; } = Environment.GetCommandLineArgs();
 }

--- a/Simple Icon File Maker/Simple Icon File Maker/Controls/PreviewImage.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Controls/PreviewImage.xaml.cs
@@ -77,9 +77,7 @@ public sealed partial class PreviewImage : UserControl
         savePicker.SuggestedFileName = $"{OriginalName}-{_sideLength}x{_sideLength}";
         savePicker.DefaultFileExtension = extension;
 
-        Window saveWindow = new();
-        IntPtr windowHandleSave = WindowNative.GetWindowHandle(saveWindow);
-        InitializeWithWindow.Initialize(savePicker, windowHandleSave);
+        InitializeWithWindow.Initialize(savePicker, App.MainWindow.WindowHandle);
 
         StorageFile file = await savePicker.PickSaveFileAsync();
 

--- a/Simple Icon File Maker/Simple Icon File Maker/Services/NavigationService.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Services/NavigationService.cs
@@ -25,7 +25,7 @@ public class NavigationService : INavigationService
         {
             if (_frame == null)
             {
-                _frame = App.m_window?.Content as Frame;
+                _frame = App.MainWindow?.Content as Frame;
                 RegisterFrameEvents();
             }
 

--- a/Simple Icon File Maker/Simple Icon File Maker/Services/StoreService.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Services/StoreService.cs
@@ -214,8 +214,7 @@ public class StoreService : IStoreService
         if (addOnProduct is null)
             return StorePurchaseStatus.ServerError;
 
-        IntPtr hwnd = WindowNative.GetWindowHandle(App.m_window);
-        InitializeWithWindow.Initialize(_context, hwnd);
+        InitializeWithWindow.Initialize(_context, App.MainWindow.WindowHandle);
 
         /// Attempt purchase
         StorePurchaseResult? result = await addOnProduct.RequestPurchaseAsync();

--- a/Simple Icon File Maker/Simple Icon File Maker/Services/ThemeSelectorService.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Services/ThemeSelectorService.cs
@@ -33,11 +33,6 @@ public class ThemeSelectorService : IThemeSelectorService
 
     public async Task SetRequestedThemeAsync()
     {
-        if (App.m_window?.Content is FrameworkElement rootElement)
-        {
-            rootElement.RequestedTheme = Theme;
-        }
-
         await Task.CompletedTask;
     }
 

--- a/Simple Icon File Maker/Simple Icon File Maker/ViewModels/MainViewModel.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/ViewModels/MainViewModel.cs
@@ -4,7 +4,6 @@ using Simple_Icon_File_Maker.Contracts.Services;
 using Simple_Icon_File_Maker.Contracts.ViewModels;
 using Windows.Storage.Pickers;
 using Windows.Storage;
-using Microsoft.UI.Xaml;
 using WinRT.Interop;
 
 namespace Simple_Icon_File_Maker.ViewModels;
@@ -33,9 +32,7 @@ public partial class MainViewModel : ObservableRecipient, INavigationAware
                 FileTypeFilter = { "*" }
             };
 
-            Window saveWindow = new();
-            IntPtr windowHandleSave = WindowNative.GetWindowHandle(saveWindow);
-            InitializeWithWindow.Initialize(picker, windowHandleSave);
+            InitializeWithWindow.Initialize(picker, App.MainWindow.WindowHandle);
 
             StorageFolder folder = await picker.PickSingleFolderAsync();
 

--- a/Simple Icon File Maker/Simple Icon File Maker/Views/AboutPage.xaml
+++ b/Simple Icon File Maker/Simple Icon File Maker/Views/AboutPage.xaml
@@ -9,8 +9,7 @@
 
     <ScrollViewer MinWidth="500">
         <StackPanel
-            MaxWidth="1000"
-            Padding="80,20,20,20"
+            Padding="80,20,80,20"
             HorizontalAlignment="Stretch"
             Spacing="12">
             <StackPanel Orientation="Horizontal" Spacing="20">

--- a/Simple Icon File Maker/Simple Icon File Maker/Views/MainPage.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Views/MainPage.xaml.cs
@@ -329,9 +329,7 @@ public sealed partial class MainPage : Page
         foreach (string extension in FileTypes.SupportedImageFormats)
             picker.FileTypeFilter.Add(extension);
 
-        Window window = new();
-        IntPtr windowHandle = WindowNative.GetWindowHandle(window);
-        InitializeWithWindow.Initialize(picker, windowHandle);
+        InitializeWithWindow.Initialize(picker, App.MainWindow.WindowHandle);
 
         StorageFile file = await picker.PickSingleFileAsync();
 
@@ -450,9 +448,7 @@ public sealed partial class MainPage : Page
         savePicker.DefaultFileExtension = ".ico";
         savePicker.SuggestedFileName = Path.GetFileNameWithoutExtension(ImagePath);
 
-        Window saveWindow = new();
-        IntPtr windowHandleSave = WindowNative.GetWindowHandle(saveWindow);
-        InitializeWithWindow.Initialize(savePicker, windowHandleSave);
+        InitializeWithWindow.Initialize(savePicker, App.MainWindow.WindowHandle);
 
         StorageFile file = await savePicker.PickSaveFileAsync();
 
@@ -494,9 +490,7 @@ public sealed partial class MainPage : Page
         savePicker.DefaultFileExtension = ".ico";
         savePicker.SuggestedFileName = Path.GetFileNameWithoutExtension(ImagePath);
 
-        Window saveWindow = new();
-        IntPtr windowHandleSave = WindowNative.GetWindowHandle(saveWindow);
-        InitializeWithWindow.Initialize(savePicker, windowHandleSave);
+        InitializeWithWindow.Initialize(savePicker, App.MainWindow.WindowHandle);
 
         StorageFile file = await savePicker.PickSaveFileAsync();
 

--- a/Simple Icon File Maker/Simple Icon File Maker/Windows/MainWindow.xaml.cs
+++ b/Simple Icon File Maker/Simple Icon File Maker/Windows/MainWindow.xaml.cs
@@ -7,6 +7,8 @@ namespace Simple_Icon_File_Maker;
 
 public sealed partial class MainWindow : WindowEx
 {
+    public readonly nint WindowHandle;
+
     private Microsoft.UI.Dispatching.DispatcherQueue dispatcherQueue;
 
     private UISettings settings;
@@ -23,6 +25,8 @@ public sealed partial class MainWindow : WindowEx
         dispatcherQueue = Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread();
         settings = new UISettings();
         settings.ColorValuesChanged += Settings_ColorValuesChanged; // cannot use FrameworkElement.ActualThemeChanged event
+
+        WindowHandle = this.GetWindowHandle();
     }
 
     // this handles updating the caption button colors correctly when windows system theme is changed


### PR DESCRIPTION
* Fix #46.
* Remove useless window creation. 
For codes like:
```
 Window saveWindow = new();
 IntPtr windowHandleSave = WindowNative.GetWindowHandle(saveWindow);
```
We can use the window handle from the MainWindow, which can help reduce memory usage and ensure the resource dispose after MainWindow is closed.